### PR TITLE
Añade la licencia al proyecto

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+La documentación del cliente @firma está licenciada bajo una licencia Creative Commons Reconocimiento-NoComercial-CompartirIgual 3.0 (CC BY-NC-SA 3.0).
+Para ver una copia de esta licencia, visita https://creativecommons.org/licenses/by-nc-sa/3.0/es/legalcode.es


### PR DESCRIPTION
De acuerdo con
https://administracionelectronica.gob.es/ctt/clienteafirma/mas, la documentación de @firma está licenciada bajo CC-BY-NC-SA 3.0

Como estaba toqueteando, me he dado cuenta que los forks necesitan también su referencia a la licencia. Con esto ya está todo en el repositorio.

Al mismo tiempo, el SF_README sólo pone las licencias referentes al programa autofirma (GPLv2-or-later y EUPLv1.1-or-later), y no la de la documentación